### PR TITLE
Removing Visual Studio 2013 compiler warnings

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -512,6 +512,7 @@ template <typename Iter> void copy(const std::string &s, Iter oi) {
 }
 
 template <typename Iter> struct serialize_str_char {
+  serialize_str_char( Iter _oi ) : oi( _oi ) {};
   Iter oi;
   void operator()(char c) {
     switch (c) {


### PR DESCRIPTION
VS2013 not so smart and generate warnings here:
picojson.h(543): warning C4610: struct 'picojson::serialize_str_char<Iter>' can never be instantiated - user defined constructor required
          with
          [
              Iter=std::back_insert_iterator<std::string>
          ]
picojson.h(543): warning C4510: 'picojson::serialize_str_char<Iter>' : default constructor could not be generated
          with
          [
              Iter=std::ostream_iterator<char,char,std::char_traits<char>>
          ]